### PR TITLE
Log win32 messages

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -294,6 +294,7 @@ func (c *Container) pollStats() {
 
 func (c *Container) Wait(exitCh <-chan struct{}) (Result, error) {
 	pr, err := c.proc.Wait(exitCh)
+	c.Logger.Logf("process exited: %d", pr.ExitStatus)
 	if err != nil {
 		return Result{}, err
 	}

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func main() {
 	if err != nil {
 		logger.Error(err, "unable to load container configuration from environment variables")
 	}
+	win32.SetLogger(logger)
 	resources := win32.GetSystemResources()
 	labels := make(map[string]string)
 	for k, v := range fields {

--- a/win32/logger.go
+++ b/win32/logger.go
@@ -24,11 +24,11 @@ var globalLogger atomic.Value
 func SetLogger(l Logger) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
-	globalLogger.Store(l)
+	globalLogger.Store(logWrapper{logger: l})
 }
 
 func init() {
-	SetLogger(noopLogger{})
+	SetLogger(logWrapper{logger: noopLogger{}})
 }
 
 func logger() Logger {
@@ -48,6 +48,22 @@ func LogError(err error, msg string) {
 	if err != nil {
 		logger().Error(err, msg)
 	}
+}
+
+type logWrapper struct {
+	logger Logger
+}
+
+func (n logWrapper) Logf(format string, v ...interface{}) {
+	n.logger.Logf(format, v...)
+}
+
+func (n logWrapper) Logln(v ...interface{}) {
+	n.logger.Logln(v...)
+}
+
+func (n logWrapper) Error(err error, msg string) {
+	n.logger.Error(err, msg)
 }
 
 // noopLogger silently discards logs

--- a/win32/process.go
+++ b/win32/process.go
@@ -169,8 +169,10 @@ func (p *Process) Wait(exitCh <-chan struct{}) (*ProcessResult, error) {
 	go func() {
 		select {
 		case <-exitCh:
+			Logf("win32: command termination requested")
 			// received a request to exit the process
 		case <-doneCh:
+			Logf("win32: command completed")
 			// done before exit signal received
 			return
 		}
@@ -182,6 +184,7 @@ func (p *Process) Wait(exitCh <-chan struct{}) (*ProcessResult, error) {
 		}
 		select {
 		case <-doneCh:
+			Logf("win32: command completed")
 			return
 		case <-time.After(p.ExitTimeout):
 			// give up -- send kill signal
@@ -190,7 +193,10 @@ func (p *Process) Wait(exitCh <-chan struct{}) (*ProcessResult, error) {
 	}()
 	go func() {
 		defer close(doneCh)
+		Logf("win32: Cmd.Wait")
 		err := p.Cmd.Wait()
+		Logf("win32: Cmd.Wait complete")
+		LogError(err, "win32: Cmd.Wait error")
 		p.mu.Lock()
 		p.ended = true
 		p.endTime = time.Now()
@@ -200,6 +206,7 @@ func (p *Process) Wait(exitCh <-chan struct{}) (*ProcessResult, error) {
 		p.mu.Unlock()
 	}()
 	<-doneCh
+	Logf("win32: process completed")
 	res := &ProcessResult{
 		StartTime: p.startTime,
 		EndTime:   p.endTime,


### PR DESCRIPTION
- Add some debug messages to win32
- Set the w32 Logger in main so that it isn't a noop anymore
- Fix a panic in SetLogger; sync.Value needs to use a consistent concrete type